### PR TITLE
Fix CDI import to use jakarta

### DIFF
--- a/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/spi/database/DatabaseHealthIndicator.java
+++ b/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/spi/database/DatabaseHealthIndicator.java
@@ -8,7 +8,7 @@ import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.utils.StringUtil;
 
-import javax.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.CDI;
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
 import java.sql.Connection;


### PR DESCRIPTION
Based on https://github.com/thomasdarimont/keycloak-health-checks/pull/36/files

This should fix the following error:
> 2024-05-10 11:03:33,415 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-1) Uncaught server error: java.lang.NoClassDefFoundError: javax/enterprise/inject/spi/CDI